### PR TITLE
Allows canceled order to be process in callback

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -4,7 +4,6 @@
 /.wordpress-org
 /node_modules
 /tests
-/vendor
 .drone.yml
 .env
 .editorconfig

--- a/classes/payment-processor.php
+++ b/classes/payment-processor.php
@@ -97,9 +97,8 @@ class Payment_Processor {
 	 */
 	public static function handle_response( $order, $payment_status = null, $redirect = true ) {
 
-		// TODO: I believe what they meant here is to check for if $order->get_date_paid() is not null.
-		// Ignore orders that are already paid.
-		if ( ! $order->needs_payment() ) {
+		// Checks for if the date paid is set to allow canceled (due to hold stock setting) ordered to be processed in case the customer takes longer time to return from Zaver to the store than expected.
+		if ( ! empty( $order->get_date_paid() ) ) {
 			ZCO()->logger()->debug(
 				'[CALLBACK]: Zaver payment do not need payment',
 				array(


### PR DESCRIPTION
The existing check for [`needs_payment`](https://woocommerce.github.io/code-reference/files/woocommerce-includes-class-wc-order.html#source-view.1723) does not suffice as it only considers a pending or failed order to be in need of payment, whereas orders that are canceled (e.g., due to hold stock setting in combination with the customer taking too long to finish the order on the Zaver payment page before returning to the store) are not processed. This would result in fulfilled payments not being processed in the WC store through the callback.

- checks for [get_date_paid](https://woocommerce.github.io/code-reference/files/woocommerce-includes-class-wc-order.html#source-view.320) instead, which is only set when the order is processing or has been completed.

https://app.clickup.com/t/8698zvwug