### PR TITLE
Change how we retrieve the order in callback, and its failed status

### DIFF
--- a/classes/hooks.php
+++ b/classes/hooks.php
@@ -182,14 +182,7 @@ final class Hooks {
 
 			Refund_Processor::handle_response( $order, $refund );
 		} catch ( Exception $e ) {
-
-			// Do not change the status if the order has already been paid.
-			if ( empty( $order->get_date_paid() ) ) {
-				// translators: %s is the error message.
-				$order->update_status( 'failed', sprintf( __( 'Failed with Zaver payment: %s', 'zco' ), $e->getMessage() ) );
-			}
-			ZCO()->logger()->error( sprintf( 'Failed with Zaver payment: %s', $e->getMessage() ), array( 'orderId' => $order->get_id() ) );
-
+			ZCO()->logger()->error( sprintf( 'An error occurred will processing the refund callback: %s', $e->getMessage() ), array( 'orderId' => $meta['orderId'] ?? 'missing' ) );
 			status_header( 400 );
 		}
 	}


### PR DESCRIPTION
Every time the customer clicks on the purchase button, a new Zaver payment will be created along with an ID. Since Zaver will continue to ping the callback, even if the order was not finalized, we cannot rely on the `orderId` that all Zaver payment IDs are associated with. Instead, we'll search WC for an order that has a matching payment ID. This ensures that the old payment IDs associated with the same order are ignored.

- in callback, retrieve WC order ID using `Helper::get_order_by_payment_id`. 
- for refunds, retrieve order ID using `Helper::get_order_by_payment_id`. Defaulting to the `orderId` is safe here since we cannot receive a refund callback unless an order actually exists.
- when catching an exception, checks if the order is already paid before setting to `failed`. If paid, we won't change the order status.

https://app.clickup.com/t/869a87ufv
https://app.clickup.com/t/869a87xqa