### PR TITLE
Pre release cleanup

### DIFF
--- a/classes/checkout-gateway.php
+++ b/classes/checkout-gateway.php
@@ -11,6 +11,7 @@ use KrokedilZCODeps\Zaver\SDK\Checkout;
 use KrokedilZCODeps\Zaver\SDK\Refund;
 use KrokedilZCODeps\Zaver\SDK\Object\PaymentStatusResponse;
 use KrokedilZCODeps\Zaver\SDK\Object\RefundResponse;
+use KrokedilZCODeps\Zaver\SDK\Utils\Error;
 use WC_Order;
 use WC_Payment_Gateway;
 use Exception;
@@ -181,7 +182,7 @@ class Checkout_Gateway extends WC_Payment_Gateway {
 				)
 			);
 		} catch ( Exception $e ) {
-			ZCO()->logger()->error( sprintf( 'Zaver error during payment process: %s', $e->getMessage() ), array( 'orderId' => $order_id ) );
+			ZCO()->logger()->error( sprintf( 'Zaver error during payment process: %s', $e->getMessage() ), Helper::add_zaver_error_details( $e, array( 'orderId' => $order_id ) ) );
 
 			$message = __( 'An error occurred - please try again, or contact site support', 'zco' );
 			wc_add_notice( $message, 'error' );
@@ -222,10 +223,13 @@ class Checkout_Gateway extends WC_Payment_Gateway {
 					'Zaver error during refund process: %s',
 					$e->getMessage()
 				),
-				array(
-					'orderId' => $order_id,
-					'amount'  => $amount,
-					'reason'  => $reason,
+				Helper::add_zaver_error_details(
+					$e,
+					array(
+						'orderId' => $order_id,
+						'amount'  => $amount,
+						'reason'  => $reason,
+					)
 				)
 			);
 
@@ -276,9 +280,7 @@ class Checkout_Gateway extends WC_Payment_Gateway {
 	 * @return PaymentStatusResponse
 	 */
 	public function receive_payment_callback() {
-		$callback = $this->api()->receiveCallback( $this->get_option( 'callback_token' ) );
-		ZCO()->logger()->info( 'Received Zaver payment callback', (array) $callback );
-		return $callback;
+		return $this->api()->receiveCallback( $this->get_option( 'callback_token' ) );
 	}
 
 	/**
@@ -287,8 +289,6 @@ class Checkout_Gateway extends WC_Payment_Gateway {
 	 * @return RefundResponse
 	 */
 	public function receive_refund_callback() {
-		$callback = $this->refund_api()->receiveCallback( $this->get_option( 'callback_token' ) );
-		ZCO()->logger()->info( 'Received Zaver refund callback', (array) $callback );
-		return $callback;
+		return $this->refund_api()->receiveCallback( $this->get_option( 'callback_token' ) );
 	}
 }

--- a/classes/order-management.php
+++ b/classes/order-management.php
@@ -10,6 +10,7 @@
 
 namespace Zaver;
 
+use Exception;
 use KrokedilZCODeps\Zaver\SDK\Config\PaymentStatus;
 use KrokedilZCODeps\Zaver\SDK\Object\PaymentCaptureRequest;
 use KrokedilZCODeps\Zaver\SDK\Object\PaymentStatusResponse;
@@ -94,71 +95,78 @@ class Order_Management {
 	 * @return void
 	 */
 	public function capture_order( $order_id, $order ) {
-		if ( ! Plugin::gateway()->is_chosen_gateway( $order ) ) {
-			return;
-		}
-
-		if ( $order->get_meta( self::CAPTURED ) ) {
-			$order->add_order_note( __( 'The Zaver order has already been captured.', 'zco' ) );
-			return;
-		}
-
-		if ( empty( $order->get_transaction_id() ) ) {
-			$note = __( 'The order is missing a transaction ID.', 'zco' );
-			$order->update_status( 'on-hold', $note );
-			return;
-		}
-
-		if ( $order->get_meta( self::CANCELED ) ) {
-			$order->add_order_note( __( 'The Zaver order was canceled and can no longer be captured.', 'zco' ) );
-			return;
-		}
-
-		if ( $order->get_meta( self::REFUNDED ) ) {
-			$order->add_order_note( __( 'The Zaver order has been refunded and can no longer be captured.', 'zco' ) );
-			return;
-		}
-
-		$payment_status = Plugin::gateway()->api()->getPaymentStatus( $order->get_transaction_id() );
-		if ( false && ! $this->can_capture( $payment_status ) ) {
-			if ( PaymentStatus::PENDING_CONFIRMATION === $payment_status->getPaymentStatus() ) {
-				$additional_note = __( ' while pending confirmation.', 'zco' );
+		try{
+			if ( ! Plugin::gateway()->is_chosen_gateway( $order ) ) {
+				return;
 			}
 
-			// translators: %s is the additional note.
-			$note = sprintf( __( 'The Zaver order cannot be captured%s', 'zco' ), empty( $additional_note ) ? '.' : $additional_note );
-			$order->add_order_note( $note );
-			return;
+			if ( $order->get_meta( self::CAPTURED ) ) {
+				$order->add_order_note( __( 'The Zaver order has already been captured.', 'zco' ) );
+				return;
+			}
+
+			if ( empty( $order->get_transaction_id() ) ) {
+				$note = __( 'The order is missing a transaction ID.', 'zco' );
+				$order->update_status( 'on-hold', $note );
+				return;
+			}
+
+			if ( $order->get_meta( self::CANCELED ) ) {
+				$order->add_order_note( __( 'The Zaver order was canceled and can no longer be captured.', 'zco' ) );
+				return;
+			}
+
+			if ( $order->get_meta( self::REFUNDED ) ) {
+				$order->add_order_note( __( 'The Zaver order has been refunded and can no longer be captured.', 'zco' ) );
+				return;
+			}
+
+			$payment_status = Plugin::gateway()->api()->getPaymentStatus( $order->get_transaction_id() );
+			if ( false && ! $this->can_capture( $payment_status ) ) {
+				if ( PaymentStatus::PENDING_CONFIRMATION === $payment_status->getPaymentStatus() ) {
+					$additional_note = __( ' while pending confirmation.', 'zco' );
+				}
+
+				// translators: %s is the additional note.
+				$note = sprintf( __( 'The Zaver order cannot be captured%s', 'zco' ), empty( $additional_note ) ? '.' : $additional_note );
+				$order->add_order_note( $note );
+				return;
+			}
+
+			// If the request fails, an ZaverError exception will be thrown. This is caught by WooCommerce which will still complete the status transition, but write an order note about the error, and include the error message from Zaver in that note. Therefore, we don't have to catch the exception here.
+			$request  = new PaymentCaptureRequest(
+				array(
+					'captureIdempotencyKey' => wp_generate_uuid4(),
+					'amount'                => $order->get_total(),
+					'currency'              => $order->get_currency(),
+					'lineItems'             => Order::get_line_items( $order ),
+				)
+			);
+			$response = Plugin::gateway()->api()->capturePayment( $order->get_transaction_id(), $request );
+
+			$note = sprintf(
+				// translators: the amount including currency.
+				__( 'The Zaver order has been captured. Captured amount: %1$.2f.', 'zco' ),
+				self::format_price( $response->getCapturedAmount(), $response->getCurrency() )
+			);
+
+			self::set_as_captured( $order );
+
+			ZCO()->logger()->info(
+				"Captured Zaver payment: {$order->get_transaction_id()}",
+				array(
+					'payload'   => $order->get_transaction_id(),
+					'response'  => $response,
+					'orderId'   => $order->get_id(),
+					'paymentId' => $order->get_transaction_id(),
+				)
+			);
+		} catch (Exception $e) {
+			ZCO()->logger()->error( sprintf( 'Zaver error when capturing order: %s', $e->getMessage() ), Helper::add_zaver_error_details( $e, array( 'orderId' => $order_id ) ) );
+			// translators: The error message.
+			$order->update_status( 'on-hold', sprintf( __( 'Failed to capture the Zaver order: %s', 'zco' ), $e->getMessage() ) );
+			$order->save();
 		}
-
-		// If the request fails, an ZaverError exception will be thrown. This is caught by WooCommerce which will still complete the status transition, but write an order note about the error, and include the error message from Zaver in that note. Therefore, we don't have to catch the exception here.
-		$request  = new PaymentCaptureRequest(
-			array(
-				'captureIdempotencyKey' => wp_generate_uuid4(),
-				'amount'                => $order->get_total(),
-				'currency'              => $order->get_currency(),
-				'lineItems'             => Order::get_line_items( $order ),
-			)
-		);
-		$response = Plugin::gateway()->api()->capturePayment( $order->get_transaction_id(), $request );
-
-		$note = sprintf(
-			// translators: the amount including currency.
-			__( 'The Zaver order has been captured. Captured amount: %1$.2f.', 'zco' ),
-			self::format_price( $response->getCapturedAmount(), $response->getCurrency() )
-		);
-
-		self::set_as_captured( $order );
-
-		ZCO()->logger()->info(
-			"Captured Zaver payment: {$order->get_transaction_id()}",
-			array(
-				'payload'   => $order->get_transaction_id(),
-				'response'  => $response,
-				'orderId'   => $order->get_id(),
-				'paymentId' => $order->get_transaction_id(),
-			)
-		);
 	}
 
 	/**
@@ -169,6 +177,7 @@ class Order_Management {
 	 * @return void
 	 */
 	public function cancel_order( $order_id, $order ) {
+		try{
 		if ( ! Plugin::gateway()->is_chosen_gateway( $order ) ) {
 			return;
 		}
@@ -221,6 +230,12 @@ class Order_Management {
 				'paymentId' => $order->get_transaction_id(),
 			)
 		);
+		} catch (Exception $e) {
+			ZCO()->logger()->error( sprintf( 'Zaver error when cancelling order: %s', $e->getMessage() ), Helper::add_zaver_error_details( $e, array( 'orderId' => $order_id ) ) );
+			// translators: The error message.
+			$order->update_status( 'on-hold', sprintf( __( 'Failed to cancel the Zaver order: %s', 'zco' ), $e->getMessage() ) );
+			$order->save();
+		}
 	}
 
 	/**

--- a/classes/session.php
+++ b/classes/session.php
@@ -89,15 +89,17 @@ class Session {
 		} catch ( \Exception $e ) {
 			\Zaver\ZCO()->logger()->critical(
 				'Failed to retrieve payment methods',
-				array(
-					'payload' => array(
-						'total'    => $total,
-						'market'   => $market,
-						'currency' => $currency,
-					),
-					'code'    => $e->getCode(),
-					'message' => $e->getMessage(),
-					'trace'   => $e->getTraceAsString(),
+				Helper::add_zaver_error_details( $e,
+					array(
+						'payload' => array(
+							'total'    => $total,
+							'market'   => $market,
+							'currency' => $currency,
+						),
+						'code'    => $e->getCode(),
+						'message' => $e->getMessage(),
+						'trace'   => $e->getTraceAsString(),
+					)
 				)
 			);
 		}

--- a/src/PaymentMethods/BaseGateway.php
+++ b/src/PaymentMethods/BaseGateway.php
@@ -177,7 +177,7 @@ abstract class BaseGateway extends WC_Payment_Gateway {
 				)
 			);
 		} catch ( Exception $e ) {
-			\Zaver\ZCO()->logger()->error( sprintf( 'Zaver error during payment process: %s', $e->getMessage() ), array( 'orderId' => $order_id ) );
+			\Zaver\ZCO()->logger()->error( sprintf( 'Zaver error during payment process: %s', $e->getMessage() ), \Zaver\Helper::add_zaver_error_details( $e, array( 'orderId' => $order_id ) ) );
 
 			$message = __( 'An error occurred - please try again, or contact site support', 'zco' );
 			wc_add_notice( $message, 'error' );
@@ -218,10 +218,13 @@ abstract class BaseGateway extends WC_Payment_Gateway {
 					'Zaver error during refund process: %s',
 					$e->getMessage()
 				),
-				array(
-					'orderId' => $order_id,
-					'amount'  => $amount,
-					'reason'  => $reason,
+				\Zaver\Helper::add_zaver_error_details(
+					$e,
+					array(
+						'orderId' => $order_id,
+						'amount'  => $amount,
+						'reason'  => $reason,
+					)
 				)
 			);
 


### PR DESCRIPTION
Improved error logging for failed HTTP requests throughout the plugin code.
Fixed not handling failed OM requests and setting the order to on-hold.
Improved the lookup for callbacks and excluded handling of CREATED callbacks to prevent unnecessary log entries for callbacks that wont be processed.