### PR TITLE
fix: defer plugin bootstrap to plugins_loaded

### DIFF
--- a/woocommerce-zaver-checkout.php
+++ b/woocommerce-zaver-checkout.php
@@ -279,8 +279,6 @@ class Plugin {
 		$this->order_management = Order_Management::get_instance();
 		OrderMetabox::register_for_payment_methods( $this->zaver_payment_gateways );
 		Hooks::instance();
-
-		add_action( 'before_woocommerce_init', array( $this, 'declare_wc_compatibility' ) );
 	}
 
 	/**
@@ -297,7 +295,7 @@ class Plugin {
 	 *
 	 * @return void
 	 */
-	public function declare_wc_compatibility() {
+	public static function declare_wc_compatibility() {
 		if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
 			// Declare HPOS compatibility.
 			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
@@ -467,4 +465,5 @@ function ZCO() {
 	return Plugin::instance();
 }
 
+add_action( 'before_woocommerce_init', array( __NAMESPACE__ . '\\Plugin', 'declare_wc_compatibility' ) );
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\ZCO' );

--- a/woocommerce-zaver-checkout.php
+++ b/woocommerce-zaver-checkout.php
@@ -467,4 +467,4 @@ function ZCO() {
 	return Plugin::instance();
 }
 
-ZCO();
+add_action( 'plugins_loaded', __NAMESPACE__ . '\\ZCO' );


### PR DESCRIPTION
The plugin's main file declared namespace Zaver; and ended with a top-level ZCO(); call. Plugin::__construct() immediately calls wc_string_to_bool(...) six times. Because of the namespace, the unqualified call resolves to Zaver\wc_string_to_bool and only falls back to the global function if PHP can find it. If WooCommerce's code isn't loaded into the running PHP process when Zaver's main file is included, the request fatals with Call to undefined function Zaver\wc_string_to_bool().

This survives normal HTTP activation (WP loads all active plugins, including WC, before any sandbox scrape), but fatals under wp-cli plugin activate --skip-plugins and similar environments where WC isn't resident in the process. The Requires Plugins: woocommerce header doesn't help — it validates DB state, not code load order.

Hooking ZCO to plugins_loaded defers initialization until WordPress has loaded all active plugins. This mirrors the bootstrap pattern used by other WooCommerce-dependent payment gateways.

Also moves the before_woocommerce_init registration out of Plugin::__construct() to file-include time. WooCommerce fires before_woocommerce_init from plugins_loaded priority -1, so registering the listener inside a default-priority plugins_loaded callback would land after the action has already fired and silently drop the HPOS compatibility declaration. Registering at file-include time also ensures HPOS compat is declared even if init_composer() fails and the constructor early-returns.